### PR TITLE
Created .gitignore

### DIFF
--- a/python_bindings/.gitignore
+++ b/python_bindings/.gitignore
@@ -1,0 +1,2 @@
+hashdb.py
+hashdb_wrap.cpp


### PR DESCRIPTION
It's useful to have this .gitignore so that the SWG-generated files don't appear as files that git thinks are unmanaged.